### PR TITLE
Pg import bug fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,6 +35,8 @@ function createWindow() {
   // Add event listener to set our global window variable to null
   // This is needed so that window is able to reopen when user relaunches the app
   win.on('closed', () => {
+    //added to overwrite .env with null every time window is closed so new import can work
+    fs.writeFileSync(path.join(__dirname, '/.env'), "", 'utf8');
     win = null;
   });
 
@@ -209,14 +211,14 @@ ipcMain.on('import-tables', (event, env) => {
   let tables;
  pgQuery(tables)
   .then((tables) => {
-    console.log("tables (main):", tables)
+    // console.log("tables (main):", tables)
     event.reply('tables-imported', tables)
   })
   .catch(err => console.error("Error importing tables from postgres"))
 })
 //--------------------- CREATE ENV FILE -------------------//
 
-function createEnvFile(env) {
+async function createEnvFile(env) {
   try {
     fs.writeFileSync(path.join(__dirname, '/.env'), env, 'utf8')
   } catch (err) {
@@ -225,8 +227,15 @@ function createEnvFile(env) {
 }
 
 ipcMain.on('create-env-file', (event, env) => {
-  console.log(env);
-  createEnvFile(env);
+  console.log('create env file URI: ', env);
+  createEnvFile(env)
+  .then(res => {
+    event.reply('env-file-created');
+    console.log('env-file-created')
+  })
+  .catch(err => {
+    console.log('error occurred in createEnvFile promise')
+  })
 });
 
 //--------------------- MENU CUSTOMIZATION -------------------//

--- a/src/components/popup/welcome.jsx
+++ b/src/components/popup/welcome.jsx
@@ -119,7 +119,7 @@ function DraggableDialog(props) {
     if (URI.slice(0, 11).toLowerCase() === 'postgres://' || URI.slice(0, 13).toLowerCase() === 'postgresql://') {
               // emitting message to electron window to open save dialog
               ipc.send('create-env-file', buildENV(URI));
-              async function importTables() {
+              function importTables() {
                 const tables = {};
                 ipc.on('tables-imported', (event, arg) => {
                   console.log("import tables, no async: ", arg)
@@ -128,7 +128,8 @@ function DraggableDialog(props) {
                 })
                 ipc.send('import-tables', tables);
               }
-              importTables();
+              //added to force table import to wait on env file creation
+              ipc.on('env-file-created', importTables);
             } else {
               console.log('That is not a valid input');
               // document.querySelector('#error').classList.remove('invisible')

--- a/src/pg-import/pgQuery.js
+++ b/src/pg-import/pgQuery.js
@@ -6,7 +6,8 @@ const dotenv = require('dotenv');
 const pgQuery = async function(fetchedTables) {
     //reads the .env config after latest update, allowing us to use new tables if a previous import has run
     dotenv.config();
-
+    const URI = process.env.DB_URI
+    
     const tableQuery = `
     SELECT table_name,
     ordinal_position as position,
@@ -28,18 +29,13 @@ const pgQuery = async function(fetchedTables) {
     FROM information_schema.constraint_column_usage
     WHERE table_schema not in ('information_schema', 'pg_catalog') AND
     table_name not in ('pg_stat_statements')
-    ORDER BY table_name;`
-    
-    let tableColumns = {};
-    
-    //this is not updating!!
-    const URI = process.env.DB_URI
+    ORDER BY table_name;`    
     
     const pool = new Pool({
       connectionString: URI,
       ssl: true,
     })
-    console.log('db uri pre pool.connect:', URI)
+    // console.log('db uri pre pool.connect:', URI)
     
     pool.connect((err, client, done) => {
       if (err) return console.log(`Error connecting to db, ${err}`);
@@ -48,92 +44,90 @@ const pgQuery = async function(fetchedTables) {
     })
     
     let queryResults = await pool.query(tableQuery)
-    .then(res => {
-        console.log("pool: ",pool)
-        console.log('db URI: ', URI)
-        console.log('tableQuery: ',res.rows)
-        tableColumns = res.rows;
-        return tableColumns;
-    })
-    .then(tableColumns => { 
-        return pool.query(constraintQuery)
-                .then(res => {
-                    // console.log('constraintQuery: ',res.rows)
-                    const result = res.rows;
-                    for(let item of result){
-                        // console.log("tablecolumns: ", tableColumns)
-                        let table = item.table_name;
-                        let col = item.column_name;
-                        for(let column of tableColumns){
-                        // console.log('column: ', column, "col: ", col)
-                            if(column.table_name == table && column.column_name == col){
-                                column.constraint = item.constraint_name;
-                            }
-                        }
-                    }
-                    const tables = {};
-                    let index = -1;
-                    tableColumns.forEach((item) => {
-                        //if table type matches index, do not create new table index
-                        if(!tables[index] || tables[index].type !== item.table_name){
-                            //increment index to move on to new table
-                            index++
-                            tables[index] = {};
-                            tables[index].type = item.table_name;
-                            tables[index].fields = {};
-                            tables[index].fieldIndex = 0;
-                            tables[index].tableID = index.toString();
-                            tables[index].fields = [];
-                        }
-                        tables[index].fieldIndex ++;
-                        
-                        // tables[index].fields[position] = {};
-                        const column = {};
-                        column.name = item.column_name;
-                        
-                        //assigns column data types from Postgres to match our app's data types
-                        switch(item.data_type){
-                            case "character varying":
-                                column.type = "String";
-                                break;
-                            case "integer":
-                                column.type = "Int";
-                                break;
-                            case "serial":
-                                column.type = "ID";
-                                break;
-                            case "boolean":
-                                column.type = "Boolean"
-                            }
-                            column.required = item.is_nullable == "YES" ? true : false;
-                            column.tableNum = index.toString();
-                            column.fieldNum = item.position;
-                            column.defaultValue = item.default_value ? item.default_value : "";
-                            //values that need to be fetched from db
-                            column.primaryKey = false;
-                            column.unique = false;
-                            column.relationSelected = false;
-                            column.relation = {
-                                tableIndex: -1,
-                                fieldIndex: -1,
-                                refType: ''
-                            },
-                            column.queryable = true;
-                            
-                            tables[index].fields.push(column)
-                        })
-                                    console.log("tables (pgquery): ", tables)
-                                    fetchedTables = tables;
-                                    return fetchedTables;
-                                    // console.log('final table column obj: ', tableColumns)
-            })
-            
+        .then(res => {
+            // console.log("pool: ",pool)
+            // console.log('db URI: ', URI)
+            // console.log('tableQuery: ',res.rows)
+            const tableColumns = res.rows;
+            return tableColumns;
         })
-        .catch(err => console.error('Error is: ', err)) 
-    let results = queryResults;
-    return results;
+        .then(tableColumns => { 
+            return pool.query(constraintQuery)
+                    .then(res => {
+                        // console.log('constraintQuery: ',res.rows)
+                        const result = res.rows;
+                        for(let item of result){
+                            // console.log("tablecolumns: ", tableColumns)
+                            let table = item.table_name;
+                            let col = item.column_name;
+                            for(let column of tableColumns){
+                            // console.log('column: ', column, "col: ", col)
+                                if(column.table_name == table && column.column_name == col){
+                                    column.constraint = item.constraint_name;
+                                }
+                            }
+                        }
+                        const tables = {};
+                        let index = -1;
+                        tableColumns.forEach((item) => {
+                            //if table type matches index, do not create new table index
+                            if(!tables[index] || tables[index].type !== item.table_name){
+                                //increment index to move on to new table
+                                index++
+                                tables[index] = {};
+                                tables[index].type = item.table_name;
+                                tables[index].fields = {};
+                                tables[index].fieldIndex = 0;
+                                tables[index].tableID = index.toString();
+                                tables[index].fields = [];
+                            }
+                            tables[index].fieldIndex ++;
+                            
+                            // tables[index].fields[position] = {};
+                            const column = {};
+                            column.name = item.column_name;
+                            
+                            //assigns column data types from Postgres to match our app's data types
+                            switch(item.data_type){
+                                case "character varying":
+                                    column.type = "String";
+                                    break;
+                                case "integer":
+                                    column.type = "Int";
+                                    break;
+                                case "serial":
+                                    column.type = "ID";
+                                    break;
+                                case "boolean":
+                                    column.type = "Boolean"
+                                }
+                                column.required = item.is_nullable == "YES" ? true : false;
+                                column.tableNum = index.toString();
+                                column.fieldNum = item.position;
+                                column.defaultValue = item.default_value ? item.default_value : "";
+                                //values that need to be fetched from db
+                                column.primaryKey = false;
+                                column.unique = false;
+                                column.relationSelected = false;
+                                column.relation = {
+                                    tableIndex: -1,
+                                    fieldIndex: -1,
+                                    refType: ''
+                                },
+                                column.queryable = true;
+                                
+                                tables[index].fields.push(column)
+                            })
+                                        // console.log("tables (pgquery): ", tables)
+                                        fetchedTables = tables;
+                                        return fetchedTables;
+                                        // console.log('final table column obj: ', tableColumns)
+                })
+                
+            })
+            .catch(err => console.error('Error is: ', err)) 
+    return queryResults;
 }
 
 module.exports = pgQuery;
     
-// console.log("tableRes: ", tableRes)

--- a/src/pg-import/pgQuery.js
+++ b/src/pg-import/pgQuery.js
@@ -1,7 +1,12 @@
 // const pool = require('./sqlPool');
 const { Pool } = require('pg');
-require("dotenv").config();
+const dotenv = require('dotenv');
+
+
 const pgQuery = async function(fetchedTables) {
+    //reads the .env config after latest update, allowing us to use new tables if a previous import has run
+    dotenv.config();
+
     const tableQuery = `
     SELECT table_name,
     ordinal_position as position,
@@ -27,13 +32,14 @@ const pgQuery = async function(fetchedTables) {
     
     let tableColumns = {};
     
-    
+    //this is not updating!!
     const URI = process.env.DB_URI
     
     const pool = new Pool({
       connectionString: URI,
       ssl: true,
     })
+    console.log('db uri pre pool.connect:', URI)
     
     pool.connect((err, client, done) => {
       if (err) return console.log(`Error connecting to db, ${err}`);
@@ -43,11 +49,13 @@ const pgQuery = async function(fetchedTables) {
     
     let queryResults = await pool.query(tableQuery)
     .then(res => {
+        console.log("pool: ",pool)
+        console.log('db URI: ', URI)
         console.log('tableQuery: ',res.rows)
         tableColumns = res.rows;
         return tableColumns;
     })
-    .then((tableColumns) => { 
+    .then(tableColumns => { 
         return pool.query(constraintQuery)
                 .then(res => {
                     // console.log('constraintQuery: ',res.rows)
@@ -122,8 +130,8 @@ const pgQuery = async function(fetchedTables) {
             
         })
         .catch(err => console.error('Error is: ', err)) 
-
-    return queryResults;
+    let results = queryResults;
+    return results;
 }
 
 module.exports = pgQuery;

--- a/src/state/store.jsx
+++ b/src/state/store.jsx
@@ -148,8 +148,6 @@ function reducer(state, action) {
       }
       //Updates the endpoint as input by the user. 
       case "ADD_APOLLO_SERVER_URI":
-        // let newStr = uriInputString;
-        // uriInputString = '';
         return {
           ...state,
           apolloServerURI: action.payload,


### PR DESCRIPTION
Changes to fix a bug where the pg import didn't work until the second or third time it was attempted. I believe it was an async issue where the db connection was attempted before the process to create the new .env file was completed. These changes solved the issue when run on Michele/Jessica's machines, but there may be other bugs.

Changes:
- wrapped create-env-file in promise to trigger event listener
- added event listener to welcome popup to trigger table import after env file created
- adjusted dotenv.config to trigger with each new import
- added clearing function to win.on close to wipe out .env file

Issues:
- this setup only allows for one db import per instance of the app. If the user wants to import tables from a different db, they have to close the app and reopen. This is because process.env.DB_URI can't be overwritten in a given instance without some special workarounds.